### PR TITLE
made a Sampler type that wraps the underlying algorithms

### DIFF
--- a/src/Fleck.jl
+++ b/src/Fleck.jl
@@ -3,6 +3,7 @@ module Fleck
 include("prefixsearch.jl")
 include("lefttrunc.jl")
 include("sample/neverdist.jl")
+include("sample/sampler.jl")
 include("sample/track.jl")
 # include("sample/interface.jl")
 include("sample/nrtransition.jl")

--- a/src/sample/sampler.jl
+++ b/src/sample/sampler.jl
@@ -5,7 +5,7 @@ export enable!, disable!, sample!
 """
     SSA{Key,Time}
 
-This abstract type represents a stochastic simulation algorithm. It is
+This abstract type represents a stochastic simulation algorithm (SSA). It is
 parametrized by the clock ID, or key, and the type used for the time, which
 is typically a Float64.
 """
@@ -72,6 +72,7 @@ and chooses which sampler should sample this clock. Add algorithms to this
 sampler like you would add them to a dictionary.
 
 # Examples
+
 Let's make one sampler for exponential distributions and one for the rest.
 We can name them with symbols. The trick is that we need to direct each kind
 of distribution to the correct sampler. Use a Float64 for time and each clock
@@ -100,19 +101,19 @@ Why don't we choose samplers by passing a function into the `MultiSampler`?
 This is an effort to ensure type safety, because if you're going to the trouble
 of using a hierarchical sampler, you clearly care about speed.
 """
-mutable struct MultiSampler{SamplerKey,Key,Time}
+mutable struct MultiSampler{SamplerKey,Key,Time,Chooser}
     propagator::Dict{SamplerKey,SSA{Key,Time}}
     when::Time
-    chooser::SamplerChoice{Key,SamplerKey}
+    chooser::Chooser
     chosen::Dict{Key,SamplerKey}
 end
 
 
 function MultiSampler{SamplerKey,Key,Time}(
-    which_sampler::SamplerChoice{Key,SamplerKey}
-    ) where {SamplerKey,Key,Time}
+    which_sampler::Chooser
+    ) where {SamplerKey,Key,Time,Chooser <: SamplerChoice{Key,SamplerKey}}
 
-    MultiSampler{SamplerKey,Key,Time}(
+    MultiSampler{SamplerKey,Key,Time,Chooser}(
         Dict{SamplerKey,SSA{Key,Time}}(),
         zero(Time),
         which_sampler,

--- a/src/sample/sampler.jl
+++ b/src/sample/sampler.jl
@@ -1,0 +1,120 @@
+
+export SingleSampler, MultiSampler
+export enable!, disable!, sample!
+
+"""
+    SSA{Key,Time}
+
+This abstract type represents a stochastic simulation algorithm. It is
+parametrized by the clock ID, or key, and the type used for the time, which
+is typically a Float64.
+"""
+abstract type SSA{Key,Time} end
+
+
+"""
+    SingleSampler{SSA,Time}(propagator::SSA)
+
+This makes a sampler from a single stochastic simulation algorithm. It combines
+the core algorithm with the rest of the state of the system, which is just
+the time.
+"""
+mutable struct SingleSampler{Algorithm,Time}
+    propagator::Algorithm
+    when::Time
+end
+
+
+function SingleSampler(propagator::SSA{Key,Time}) where {Key,Time}
+    SingleSampler{SSA{Key,Time},Time}(propagator, zero(Time))
+end
+
+
+function sample!(sampler::SingleSampler, rng::AbstractRNG)
+    when, transition = next(sampler.propagator, sampler.when, rng)
+    if transition !== nothing
+        sampler.when = when
+        disable!(sampler.propagator, transition, sampler.when)
+    end
+    return (when, transition)
+end
+
+
+function enable!(
+    sampler::SingleSampler, clock, distribution::UnivariateDistribution, te, rng::AbstractRNG)
+    enable!(sampler.propagator, clock, distribution, te, sampler.when, rng)
+end
+
+
+function disable!(sampler::SingleSampler, clock)
+    disable!(sampler.propagator, clock, sampler.when)
+end
+
+
+"""
+    MultiSampler{SamplerKey,Key,Time}(which_sampler::Function)
+
+This makes a sampler that uses multiple stochastic sampling algorithms (SSA) to
+determine the next transition to fire. It returns the soonest transition of all
+of the algorithms. The `which_sampler` function looks at the clock ID, or key,
+and chooses which sampler should sample this clock. Add algorithms to this
+sampler like you would add them to a dictionary.
+"""
+mutable struct MultiSampler{SamplerKey,Key,Time}
+    propagator::Dict{SamplerKey,SSA{Key,Time}}
+    when::Time
+    which_sampler::Function
+end
+
+
+function MultiSampler{SamplerKey,Key,Time}(which_sampler::Function) where {SamplerKey,Key,Time}
+    MultiSampler{SamplerKey,Key,Time}(
+        Dict{SamplerKey,SSA{Key,Time}}(),
+        zero(Time),
+        which_sampler
+        )
+end
+
+
+function Base.setindex!(
+    sampler::MultiSampler{SamplerKey,Key,Time}, algorithm::SSA{Key,Time}, sampler_key::SamplerKey
+    ) where {SamplerKey,Key,Time}
+    sampler.propagator[sampler_key] = algorithm
+end
+
+
+function sample!(
+    sampler::MultiSampler{SamplerKey,Key,Time},
+    rng::AbstractRNG
+    ) where {SamplerKey,Key,Time}
+
+    least_when::Time = typemax(Time)
+    least_transition::Union{Nothing,Key} = nothing
+    least_source::Union{Nothing,SamplerKey} = nothing
+    for i in eachindex(sampler.propagator)
+        when, transition = next(sampler.propagator[i], sampler.when, rng)
+        if when < least_when
+            least_when = when
+            least_transition = transition
+            least_source = i
+        end
+    end
+    if least_transition !== nothing
+        sampler.when = least_when
+        disable!(sampler.propagator[least_source], least_transition, least_when)
+    end
+    return (least_when, least_transition)
+end
+
+
+function enable!(
+    sampler::MultiSampler, clock, distribution::UnivariateDistribution, te, rng::AbstractRNG
+    )
+    propagator = sampler.propagator[sampler.which_sampler(clock)]
+    enable!(propagator, clock, distribution, te, sampler.when, rng)
+end
+
+
+function disable!(sampler::MultiSampler, clock)
+    disable!(sampler.propagator[sampler.which_sampler(clock)], clock, sampler.when)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,9 +35,15 @@ end
 end
 
 
+@testset "test_sampler.jl" begin
+    include("test_sampler.jl")
+end
+
+
 @testset "test_vas.jl" begin
     include("test_vas.jl")
 end
+
 
 @testset "test_vas_integrate.jl" begin
     include("test_vas_integrate.jl")

--- a/test/test_firsttofire.jl
+++ b/test/test_firsttofire.jl
@@ -6,9 +6,9 @@ using SafeTestsets
     using Random: Xoshiro
     using Distributions: Exponential
 
-    sampler = FirstToFire{Int}()
+    sampler = FirstToFire{Int64,Float64}()
     rng = Xoshiro(90422342)
-    enabled = Set{Int}()
+    enabled = Set{Int64}()
     for (clock_id, propensity) in enumerate([0.3, 0.2, 0.7, 0.001, 0.25])
         enable!(sampler, clock_id, Exponential(propensity), 0.0, 0.0, rng)
         push!(enabled, clock_id)
@@ -31,7 +31,7 @@ end
     using Fleck
     using Random: Xoshiro
 
-    propagator = FirstToFire{Int64}()
+    propagator = FirstToFire{Int64,Float64}()
 
     for (clock, when_fire) in [(1, 7.9), (2, 12.3), (3, 3.7), (4, 0.00013), (5, 0.2)]
         heap_handle = push!(propagator.firing_queue, Fleck.OrderedSample{Int64}(clock, when_fire))

--- a/test/test_sampler.jl
+++ b/test/test_sampler.jl
@@ -21,26 +21,42 @@ using SafeTestsets
 end
 
 
+module MultiSamplerHelp
+    using Fleck
+    using Distributions: Exponential, UnivariateDistribution
+
+    struct ByDistribution <: SamplerChoice{Int64,Int64} end
+
+    function Fleck.choose_sampler(
+        chooser::ByDistribution, clock::Int64, distribution::Exponential
+        )::Int64
+        return 1
+    end
+    function Fleck.choose_sampler(
+        chooser::ByDistribution, clock::Int64, distribution::UnivariateDistribution
+        )::Int64
+        return 2
+    end
+end
+
+
 @safetestset multisampler_smoke = "MultiSampler smoke" begin
     using Random: Xoshiro
-    using Fleck: FirstToFire, MultiSampler, enable!, disable!, sample!
-    using Distributions: Exponential
+    using Fleck: FirstToFire, MultiSampler, enable!, disable!, sample!, choose_sampler
+    using ..MultiSamplerHelp: ByDistribution
+    using Distributions: Exponential, Gamma
 
-    chooser = clock_id -> begin
-        if clock_id < 4
-            return 1
-        else
-            return 2
-        end
-    end
-
-    sampler = MultiSampler{Int64,Int64,Float64}(chooser)
+    sampler = MultiSampler{Int64,Int64,Float64}(ByDistribution())
     sampler[1] = FirstToFire{Int64,Float64}()
     sampler[2] = FirstToFire{Int64,Float64}()
     rng = Xoshiro(90422342)
     enabled = Set{Int64}()
     for (clock_id, propensity) in enumerate([0.3, 0.2, 0.7, 0.001, 0.25])
-        enable!(sampler, clock_id, Exponential(propensity), 0.0, rng)
+        if clock_id < 3
+            enable!(sampler, clock_id, Exponential(propensity), 0.0, rng)
+        else
+            enable!(sampler, clock_id, Gamma(propensity), 0.0, rng)
+        end
         push!(enabled, clock_id)
     end
     when, which = sample!(sampler, rng)

--- a/test/test_sampler.jl
+++ b/test/test_sampler.jl
@@ -1,0 +1,52 @@
+using SafeTestsets
+
+@safetestset singlesampler_smoke = "SingleSampler smoke" begin
+    using Random: Xoshiro
+    using Fleck: FirstToFire, SingleSampler, enable!, disable!, sample!
+    using Distributions: Exponential
+
+    sampler = SingleSampler(FirstToFire{Int64,Float64}())
+    rng = Xoshiro(90422342)
+    enabled = Set{Int64}()
+    for (clock_id, propensity) in enumerate([0.3, 0.2, 0.7, 0.001, 0.25])
+        enable!(sampler, clock_id, Exponential(propensity), 0.0, rng)
+        push!(enabled, clock_id)
+    end
+    when, which = sample!(sampler, rng)
+    delete!(enabled, when)
+    todisable = collect(enabled)[1]
+    disable!(sampler, todisable)
+    enable!(sampler, 35, Exponential(), when, rng)
+    when, which = sample!(sampler, rng)
+end
+
+
+@safetestset multisampler_smoke = "MultiSampler smoke" begin
+    using Random: Xoshiro
+    using Fleck: FirstToFire, MultiSampler, enable!, disable!, sample!
+    using Distributions: Exponential
+
+    chooser = clock_id -> begin
+        if clock_id < 4
+            return 1
+        else
+            return 2
+        end
+    end
+
+    sampler = MultiSampler{Int64,Int64,Float64}(chooser)
+    sampler[1] = FirstToFire{Int64,Float64}()
+    sampler[2] = FirstToFire{Int64,Float64}()
+    rng = Xoshiro(90422342)
+    enabled = Set{Int64}()
+    for (clock_id, propensity) in enumerate([0.3, 0.2, 0.7, 0.001, 0.25])
+        enable!(sampler, clock_id, Exponential(propensity), 0.0, rng)
+        push!(enabled, clock_id)
+    end
+    when, which = sample!(sampler, rng)
+    delete!(enabled, when)
+    todisable = collect(enabled)[1]
+    disable!(sampler, todisable)
+    enable!(sampler, 35, Exponential(), when, rng)
+    when, which = sample!(sampler, rng)
+end

--- a/test/test_vas_integrate.jl
+++ b/test/test_vas_integrate.jl
@@ -63,7 +63,7 @@ end
 
     cnt = 30
     vas = VectorAdditionSystem(sample_sir(cnt)...)
-    sampler = FirstToFire{Int}()
+    sampler = FirstToFire{Int64,Float64}()
 
     starting = zeros(Int, 3 * cnt)
     starting[2:cnt] .= 1


### PR DESCRIPTION
The sampler should know the current simulation time. That causes problems if you have hierarchical samplers, so this PR creates a hierarchical sampler that _contains_ multiple SSA algorithms. That's the idea, and it shows why there is a difference between the next() function to get the next time and the sample!() function that chooses the next time.

It does raise a question about enabling times. Maybe it's easier for user code to give a relative enabling time, so the simulation at time t=37.2 doesn't say "enable this function at time 36.4" but says "enable this function so it's offset by -0.8 seconds into the past.